### PR TITLE
修复tf2运行mlm时的bug

### DIFF
--- a/bert4keras/backend.py
+++ b/bert4keras/backend.py
@@ -72,42 +72,6 @@ def piecewise_linear(t, schedule):
 
     return x
 
-
-def search_layer(inputs, name, exclude_from=None):
-    """根据inputs和name来搜索层
-    说明：inputs为某个层或某个层的输出；name为目标层的名字。
-    实现：根据inputs一直往上递归搜索，直到发现名字为name的层为止；
-         如果找不到，那就返回None。
-    """
-    if exclude_from is None:
-        exclude_from = set()
-
-    if isinstance(inputs, keras.layers.Layer):
-        layer = inputs
-    else:
-        layer = inputs._keras_history[0]
-
-    if layer.name == name:
-        return layer
-    elif layer in exclude_from:
-        return None
-    else:
-        exclude_from.add(layer)
-        if isinstance(layer, keras.models.Model):
-            model = layer
-            for layer in model.layers:
-                if layer.name == name:
-                    return layer
-        inbound_layers = layer._inbound_nodes[0].inbound_layers
-        if not isinstance(inbound_layers, list):
-            inbound_layers = [inbound_layers]
-        if len(inbound_layers) > 0:
-            for layer in inbound_layers:
-                layer = search_layer(layer, name, exclude_from)
-                if layer is not None:
-                    return layer
-
-
 def sequence_masking(x, mask, mode=0, axis=None):
     """为序列条件mask的函数
     mask: 形如(batch_size, seq_len)的0-1矩阵；


### PR DESCRIPTION
1.主要是修复了使用tf2运行with_mlm=True程序会产生Inputs to eager execution function cannot be Keras symbolic tensors, but found [<tf.Tensor 'MLM-Proba/transpose:0' shape=(768, 21128) dtype=float32>]，类似的由于tf2的动态图机制导致的错误。我只测试了bert模型。其他模型的EmbeddingDense我也做了类似修改。
2.另外改了一下bert模型with_nsp=True，如果没有设置with_pool=True会导致activations.get报错。

