### PR TITLE
fix(tokenizers): add default _token_unk_id

### DIFF
--- a/bert4keras/tokenizers.py
+++ b/bert4keras/tokenizers.py
@@ -62,6 +62,8 @@ class BasicTokenizer(object):
         self._token_mask = '[MASK]'
         self._token_start = token_start
         self._token_end = token_end
+        # 默认的unk，id为0
+        self._token_unk_id = 0
 
     def tokenize(self, text, maxlen=None):
         """分词函数


### PR DESCRIPTION
`self._token_dict.get(token, self._token_unk_id) ` 有用到`default _token_unk_id`但未定义，加载albert时出错 ：

AttributeError: 'Tokenizer' object has no attribute '_token_unk_id'