### PR TITLE
fix without a_bias will delete p_bias error

### DIFF
--- a/bert4keras/models.py
+++ b/bert4keras/models.py
@@ -154,9 +154,10 @@ class Transformer(object):
                         if arguments.get('a_bias'):
                             a_bias = Add(name=name + '-Attention-Bias'
                                         )([inputs[3], self.attention_scores])
+                            inputs = inputs[:3] + [a_bias] + inputs[4:]
                         else:
                             a_bias = self.attention_scores
-                        inputs = inputs[:3] + [a_bias] + inputs[4:]
+                            inputs = inputs[:3] + [a_bias] + inputs[3:]
                         arguments['a_bias'] = True
                     o, a = self.layers[name](inputs, **arguments)
                     self.attention_scores = a


### PR DESCRIPTION
if has a_bias, then update ,else, should insert not update,because without a_bias,this will delete the original inputs[3],like p_bias